### PR TITLE
Added Query Params to Create Document Endpoints

### DIFF
--- a/src/main/java/com/org/project/controller/DocumentController.java
+++ b/src/main/java/com/org/project/controller/DocumentController.java
@@ -127,18 +127,21 @@ public class DocumentController {
     @PostMapping("/organization/{org_id}/create")
     public ResponseEntity<Map<String, Object>> createDocument(
             @PathVariable("org_id") String organizationId,
+            @RequestParam(value = "name", required = false) String documentName,
+            @RequestParam(value = "parent_folder_id", required = false) String parentFolderId,
             HttpServletRequest securedRequest
     ) {
         String userId = (String) securedRequest.getAttribute("user_id");
-        File newOrganizationDocument = documentService.createOrganizationDocument(userId, organizationId);
 
-        if (newOrganizationDocument == null) {
-            return new ResponseEntity<>(Map.of("error", "Failed to create document"), HttpStatus.INTERNAL_SERVER_ERROR);
+        try {
+            File newOrganizationDocument = documentService.createOrganizationDocument(userId, organizationId, documentName, parentFolderId);
+            Map<String, Object> response = new HashMap<>();
+            response.put("document_id", newOrganizationDocument.getId());
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
         }
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("document_id", newOrganizationDocument.getId());
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", "An error occurred while creating the document"));
+        }
     }
 
     @OrganizationViewer
@@ -173,17 +176,19 @@ public class DocumentController {
 
     @PostMapping("/user/create")
     public ResponseEntity<Map<String, Object>> createUserDocument(
-            HttpServletRequest request
+            HttpServletRequest request,
+            @RequestParam(value = "name", required = false) String documentName,
+            @RequestParam(value = "parent_folder_id", required = false) String parentFolderId
     ) {
         String userId = (String) request.getAttribute("user_id");
-        File newUserDocument = documentService.createUserDocument(userId);
 
-        if (newUserDocument == null) {
-            return new ResponseEntity<>(Map.of("error", "Failed to create document"), HttpStatus.INTERNAL_SERVER_ERROR);
+        try {
+            File newUserDocument = documentService.createUserDocument(userId, documentName, parentFolderId);
+            Map<String, Object> response = new HashMap<>();
+            response.put("document_id", newUserDocument.getId());
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", "An error occurred while creating the document"));
         }
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("document_id", newUserDocument.getId());
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/test/java/com/org/project/controller/DocumentControllerTest.java
+++ b/src/test/java/com/org/project/controller/DocumentControllerTest.java
@@ -1,0 +1,168 @@
+package com.org.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.org.project.model.File;
+import com.org.project.model.Folder;
+import com.org.project.model.Organization;
+import com.org.project.model.User;
+import com.org.project.service.DocumentService;
+import com.org.project.service.OrganizationService;
+import com.org.project.test_configs.BaseControllerTest;
+import com.org.project.test_configs.ControllerTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ControllerTest(DocumentController.class)
+public class DocumentControllerTest extends BaseControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private DocumentService documentService;
+
+    @MockBean
+    private OrganizationService organizationService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = Mockito.mock(User.class);
+        when(testUser.getId()).thenReturn("test_id");
+        when(testUser.getEmail()).thenReturn("test@example.com");
+        when(testUser.getProvider()).thenReturn(User.Provider.LOCAL);
+        when(testUser.getAuthVersion()).thenReturn(1);
+    }
+
+    @Nested
+    class OrganizationTests {
+        private Organization testOrganization;
+        private Folder rootOrganizationFolder;
+        private Folder parentOrganizationFolder;
+        private File testRootFile;
+        private File testParentFile;
+
+        @BeforeEach
+        void setUp() {
+            testOrganization = Mockito.mock(Organization.class);
+            when(testOrganization.getId()).thenReturn("test_org_id");
+            when(testOrganization.getName()).thenReturn("test_org");
+
+            rootOrganizationFolder = Mockito.mock(Folder.class);
+            when(rootOrganizationFolder.getName()).thenReturn("root");
+            when(rootOrganizationFolder.getId()).thenReturn("root_folder_id");
+            when(rootOrganizationFolder.getOrganization()).thenReturn(testOrganization);
+
+            parentOrganizationFolder = Mockito.mock(Folder.class);
+            when(parentOrganizationFolder.getName()).thenReturn("parent");
+            when(parentOrganizationFolder.getId()).thenReturn("parent_folder_id");
+            when(parentOrganizationFolder.getOrganization()).thenReturn(testOrganization);
+            when(parentOrganizationFolder.getParentFolder()).thenReturn(rootOrganizationFolder);
+
+            testRootFile = Mockito.mock(File.class);
+            when(testRootFile.getId()).thenReturn("root_file_id");
+            when(testRootFile.getName()).thenReturn("root_file");
+            when(testRootFile.getFolder()).thenReturn(rootOrganizationFolder);
+
+            testParentFile = Mockito.mock(File.class);
+            when(testParentFile.getId()).thenReturn("parent_file_id");
+            when(testParentFile.getName()).thenReturn("parent_file");
+            when(testParentFile.getFolder()).thenReturn(parentOrganizationFolder);
+        }
+
+        @Nested
+        class CreateOrganizationDocumentTests {
+            @Test
+            void shouldReturn201AndDocumentIdWhenDocumentIsCreated() throws Exception {
+                File testFile = Mockito.mock(File.class);
+                when(testFile.getId()).thenReturn("test_file_id");
+                when(documentService.createOrganizationDocument(any(), any(), any(), any())).thenReturn(testFile);
+
+                mockMvc.perform(post("/document/organization/{org_id}/create", testOrganization.getId())
+                                .param("name", "test_document")
+                                .param("parent_folder_id", parentOrganizationFolder.getId())
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.document_id").value(testFile.getId()));
+            }
+
+            @Test
+            void shouldReturn500WhenDocumentCreationFails() throws Exception {
+                when(documentService.createOrganizationDocument(any(), any(), any(), any())).thenThrow(new RuntimeException("Creation failed"));
+
+                mockMvc.perform(post("/document/organization/{org_id}/create", testOrganization.getId())
+                                .param("name", "test_document")
+                                .param("parent_folder_id", parentOrganizationFolder.getId())
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.error").value("An error occurred while creating the document"));
+            }
+        }
+    }
+
+    @Nested
+    class UserTests {
+        private Folder testFolder;
+        private File testFile;
+
+        @BeforeEach
+        void setUp() {
+            testFolder = Mockito.mock(Folder.class);
+            when(testFolder.getName()).thenReturn("test_folder");
+            when(testFolder.getId()).thenReturn("test_folder_id");
+            when(testFolder.getUser()).thenReturn(testUser);
+
+            testFile = Mockito.mock(File.class);
+            when(testFile.getId()).thenReturn("test_file_id");
+            when(testFile.getName()).thenReturn("test_file");
+            when(testFile.getFolder()).thenReturn(testFolder);
+        }
+
+        @Nested
+        class CreateUserDocumentTests {
+            @Test
+            void shouldReturn201AndDocumentIdWhenDocumentIsCreated() throws Exception {
+                when(documentService.createUserDocument(any(), any(), any())).thenReturn(testFile);
+
+                mockMvc.perform(post("/document/user/create")
+                                .param("name", "test_document")
+                                .param("parent_folder_id", testFolder.getId())
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.document_id").value(testFile.getId()));
+            }
+
+            @Test
+            void shouldReturn500WhenDocumentCreationFails() throws Exception {
+                when(documentService.createUserDocument(any(), any(), any())).thenThrow(new RuntimeException("Creation failed"));
+
+                mockMvc.perform(post("/document/user/create")
+                                .param("name", "test_document")
+                                .param("parent_folder_id", testFolder.getId())
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.error").value("An error occurred while creating the document"));
+            }
+        }
+    }
+}

--- a/src/test/java/com/org/project/controller/FolderControllerTest.java
+++ b/src/test/java/com/org/project/controller/FolderControllerTest.java
@@ -3,11 +3,13 @@ package com.org.project.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.org.project.model.Folder;
+import com.org.project.model.Organization;
 import com.org.project.model.User;
 import com.org.project.service.FolderService;
 import com.org.project.test_configs.BaseControllerTest;
 import com.org.project.test_configs.ControllerTest;
 
+import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,37 +52,95 @@ public class FolderControllerTest extends BaseControllerTest {
     }
 
     @Nested
-    class CreateUserFolder {
-        @Test
-        void shouldReturn201AndFolderIdWhenFolderIsCreated() throws Exception {
-            when(folderService.createUserFolder(any(), any(), any())).thenReturn(noParentUserFolder);
+    class UserTests {
+        @Nested
+        class CreateUserFolder {
+            @Test
+            void shouldReturn201AndFolderIdWhenFolderIsCreated() throws Exception {
+                when(folderService.createUserFolder(any(), any(), any())).thenReturn(noParentUserFolder);
 
-            mockMvc.perform(post("/folder/user/create")
-                            .param("name", "test_folder")
-                            .requestAttr("user_id", testUser.getId())
-                    )
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.folder_id").value(noParentUserFolder.getId()));
+                mockMvc.perform(post("/folder/user/create")
+                                .param("name", "test_folder")
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.folder_id").value(noParentUserFolder.getId()));
+            }
+
+            @Test
+            void shouldReturn500AndErrorMessageWhenFolderCreationFails() throws Exception {
+                when(folderService.createUserFolder(any(), any(), any())).thenThrow(new RuntimeException("Failed to create folder"));
+
+                mockMvc.perform(post("/folder/user/create")
+                                .param("name", "test_folder")
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.error").value("An error occurred while creating the folder"));
+            }
+
+            @Test
+            void shouldReturn400WhenFolderNameIsMissing() throws Exception {
+                mockMvc.perform(post("/folder/user/create")
+                                .requestAttr("user_id", testUser.getId())
+                        )
+                        .andExpect(status().isBadRequest());
+            }
+        }
+    }
+
+    @Nested
+    class OrganizationTests {
+        private Organization testOrganizaton;
+        private Folder rootOrganizationFolder;
+        private Folder parentOrganizationFolder;
+
+        @BeforeEach
+        void setUp() {
+            testOrganizaton = Mockito.mock(Organization.class);
+            when(testOrganizaton.getId()).thenReturn("test_organization_id");
+            when(testOrganizaton.getName()).thenReturn("test_organization");
+
+            rootOrganizationFolder = Mockito.mock(Folder.class);
+            when(rootOrganizationFolder.getName()).thenReturn("root_folder");
+            when(rootOrganizationFolder.getId()).thenReturn("root_folder_id");
+            when(rootOrganizationFolder.getOrganization()).thenReturn(testOrganizaton);
+
+            parentOrganizationFolder = Mockito.mock(Folder.class);
+            when(parentOrganizationFolder.getName()).thenReturn("parent_folder");
+            when(parentOrganizationFolder.getId()).thenReturn("parent_folder_id");
+            when(parentOrganizationFolder.getOrganization()).thenReturn(testOrganizaton);
         }
 
-        @Test
-        void shouldReturn500AndErrorMessageWhenFolderCreationFails() throws Exception {
-            when(folderService.createUserFolder(any(), any(), any())).thenThrow(new RuntimeException("Failed to create folder"));
+        @Nested
+        class CreateOrganizationFolder {
+            @Test
+            void shouldReturn201AndFolderIdWhenFolderIsCreated() throws Exception {
+                when(folderService.createOrganizationFolder(any(), any(), any())).thenReturn(rootOrganizationFolder);
 
-            mockMvc.perform(post("/folder/user/create")
-                            .param("name", "test_folder")
-                            .requestAttr("user_id", testUser.getId())
-                    )
-                    .andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.error").value("An error occurred while creating the folder"));
-        }
+                mockMvc.perform(post("/folder/organization/{organization_id}/create", testOrganizaton.getId())
+                                .param("name", "root_folder")
+                        )
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.folder_id").value(rootOrganizationFolder.getId()));
+            }
 
-        @Test
-        void shouldReturn400WhenFolderNameIsMissing() throws Exception {
-            mockMvc.perform(post("/folder/user/create")
-                            .requestAttr("user_id", testUser.getId())
-                    )
-                    .andExpect(status().isBadRequest());
+            @Test
+            void shouldReturn500AndErrorMessageWhenFolderCreationFails() throws Exception {
+                when(folderService.createOrganizationFolder(any(), any(), any())).thenThrow(new RuntimeException("Failed to create folder"));
+
+                mockMvc.perform(post("/folder/organization/{organization_id}/create", testOrganizaton.getId())
+                                .param("name", "root_folder")
+                        )
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.error").value("An error occurred while creating the folder"));
+            }
+
+            @Test
+            void shouldReturn400WhenFolderNameIsMissing() throws Exception {
+                mockMvc.perform(post("/folder/organization/{organization_id}/create", testOrganizaton.getId()))
+                        .andExpect(status().isBadRequest());
+            }
         }
     }
 }

--- a/src/test/java/com/org/project/service/DocumentServiceTest.java
+++ b/src/test/java/com/org/project/service/DocumentServiceTest.java
@@ -1,0 +1,230 @@
+package com.org.project.service;
+
+import com.org.project.exception.ParentFolderPermissionException;
+import com.org.project.model.*;
+import com.org.project.repository.FileContentRelationRepository;
+import com.org.project.repository.FileRepository;
+import com.org.project.repository.FolderRepository;
+import com.org.project.repository.OrganizationUserRelationRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DocumentServiceTest {
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private OrganizationUserRelationRepository organizationUserRelationRepository;
+
+    @Mock
+    private OrganizationService organizationService;
+
+    @Mock
+    private FolderService folderService;
+
+    @Mock
+    private FileRepository fileRepository;
+
+    @Mock
+    private FolderRepository folderRepository;
+
+    @Mock
+    private FileContentRelationRepository fileContentRelationRepository;
+
+    @InjectMocks
+    private DocumentService documentService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        testUser = Mockito.mock(User.class);
+        when(testUser.getId()).thenReturn("test_user_id");
+        when(testUser.getEmail()).thenReturn("test@example.com");
+        when(testUser.getProvider()).thenReturn(User.Provider.LOCAL);
+        when(testUser.getAuthVersion()).thenReturn(1);
+    }
+
+    @Nested
+    class UserDocumentTests {
+        private File testRootFile;
+        private File testParentFile;
+        private Folder testParentFolder;
+        private Folder testRootFolder;
+
+        @BeforeEach
+        void setUp() {
+            testRootFile = Mockito.mock(File.class);
+            when(testRootFile.getId()).thenReturn("test_root_file_id");
+            when(testRootFile.getName()).thenReturn("test_root_file");
+            when(testRootFile.getFolder()).thenReturn(testRootFolder);
+
+            testParentFile = Mockito.mock(File.class);
+            when(testParentFile.getId()).thenReturn("test_parent_file_id");
+            when(testParentFile.getName()).thenReturn("test_parent_file");
+            when(testParentFile.getFolder()).thenReturn(testParentFolder);
+
+            testParentFolder = Mockito.mock(Folder.class);
+            when(testParentFolder.getId()).thenReturn("test_parent_folder_id");
+            when(testParentFolder.getName()).thenReturn("test_parent_folder");
+            when(testParentFolder.getUser()).thenReturn(testUser);
+            when(testParentFolder.getParentFolder()).thenReturn(testRootFolder);
+
+            testRootFolder = Mockito.mock(Folder.class);
+            when(testRootFolder.getId()).thenReturn("test_root_folder_id");
+            when(testRootFolder.getName()).thenReturn("test_root_folder");
+            when(testRootFolder.getUser()).thenReturn(testUser);
+        }
+
+        @Nested
+        class CreateUserDocument {
+            @Test
+            void shouldCreateDocumentWithValidInputs() {
+                when(folderService.canUserAccessFolder(any(), any())).thenReturn(true);
+                when(entityManager.getReference(Folder.class, testParentFolder.getId())).thenReturn(testParentFolder);
+                when(entityManager.getReference(User.class, testUser.getId())).thenReturn(testUser);
+
+                File createdFile = Mockito.mock(File.class);
+                when(createdFile.getId()).thenReturn("new_file_id");
+                when(fileContentRelationRepository.save(any(FileContentRelation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+                when(fileRepository.save(any(File.class))).thenReturn(createdFile);
+
+                File result = documentService.createUserDocument(testUser.getId(), "New Document", testParentFolder.getId());
+
+                assertNotNull(result);
+                assertEquals("new_file_id", result.getId());
+                verify(fileRepository, times(1)).save(any(File.class));
+                verify(fileContentRelationRepository, times(1)).save(any(FileContentRelation.class));
+            }
+
+            @Test
+            void shouldThrowPermissionExceptionIfUserCannotAccessFolder() {
+                when(folderService.canUserAccessFolder(any(), any())).thenReturn(false);
+
+                assertThrows(
+                        ParentFolderPermissionException.class,
+                        () -> documentService.createUserDocument(testUser.getId(), "New Document", testParentFolder.getId())
+                );
+
+                verify(fileRepository, never()).save(any(File.class));
+                verify(fileContentRelationRepository, never()).save(any(FileContentRelation.class));
+            }
+
+            @Test
+            void shouldCreateDocumentInRootFolderIfParentFolderIdIsNull() {
+                when(folderService.getRootUserFolder(testUser.getId())).thenReturn(testRootFolder);
+                when(entityManager.getReference(User.class, testUser.getId())).thenReturn(testUser);
+
+                File createdFile = Mockito.mock(File.class);
+                when(createdFile.getId()).thenReturn("new_file_id");
+
+                when(fileRepository.save(any(File.class))).thenReturn(createdFile);
+                when(fileContentRelationRepository.save(any(FileContentRelation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+                File result = documentService.createUserDocument(testUser.getId(), "New Document", null);
+
+                assertNotNull(result);
+                assertEquals("new_file_id", result.getId());
+                verify(folderService, times(1)).getRootUserFolder(testUser.getId());
+                verify(fileRepository, times(1)).save(any(File.class));
+                verify(fileContentRelationRepository, times(1)).save(any(FileContentRelation.class));
+            }
+        }
+    }
+
+    @Nested
+    class OrganizationDocumentTests {
+        private Organization testOrganization;
+        private Folder rootOrganizationFolder;
+        private Folder parentOrganizationFolder;
+
+        @BeforeEach
+        void setUp() {
+            testOrganization = Mockito.mock(Organization.class);
+            when(testOrganization.getId()).thenReturn("test_org_id");
+            when(testOrganization.getName()).thenReturn("test_org");
+
+            rootOrganizationFolder = Mockito.mock(Folder.class);
+            when(rootOrganizationFolder.getName()).thenReturn("root");
+            when(rootOrganizationFolder.getId()).thenReturn("root_folder_id");
+            when(rootOrganizationFolder.getOrganization()).thenReturn(testOrganization);
+
+            parentOrganizationFolder = Mockito.mock(Folder.class);
+            when(parentOrganizationFolder.getName()).thenReturn("parent");
+            when(parentOrganizationFolder.getId()).thenReturn("parent_folder_id");
+            when(parentOrganizationFolder.getOrganization()).thenReturn(testOrganization);
+            when(parentOrganizationFolder.getParentFolder()).thenReturn(rootOrganizationFolder);
+        }
+
+        @Nested
+        class CreateOrganizationDocument {
+            @Test
+            void shouldCreateDocumentWithValidInputs() {
+                when(folderService.canOrganizationAccessFolder(any(), any())).thenReturn(true);
+                when(entityManager.getReference(Folder.class, parentOrganizationFolder.getId())).thenReturn(parentOrganizationFolder);
+                when(entityManager.getReference(User.class, testUser.getId())).thenReturn(testUser);
+
+                File createdFile = Mockito.mock(File.class);
+                when(createdFile.getId()).thenReturn("new_file_id");
+                when(fileContentRelationRepository.save(any(FileContentRelation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+                when(fileRepository.save(any(File.class))).thenReturn(createdFile);
+
+                File result = documentService.createOrganizationDocument(testUser.getId(), testOrganization.getId(), "New Document", parentOrganizationFolder.getId());
+
+                assertNotNull(result);
+                assertEquals("new_file_id", result.getId());
+                verify(fileRepository, times(1)).save(any(File.class));
+                verify(folderService, times(0)).getRootOrganizationFolder(testOrganization.getId());
+                verify(fileContentRelationRepository, times(1)).save(any(FileContentRelation.class));
+            }
+
+            @Test
+            void shouldThrowPermissionExceptionIfUserCannotAccessFolder() {
+                when(folderService.canOrganizationAccessFolder(any(), any())).thenReturn(false);
+
+                assertThrows(
+                        ParentFolderPermissionException.class,
+                        () -> documentService.createOrganizationDocument(testUser.getId(), testOrganization.getId(), "New Document", parentOrganizationFolder.getId())
+                );
+
+                verify(fileRepository, never()).save(any(File.class));
+                verify(fileContentRelationRepository, never()).save(any(FileContentRelation.class));
+            }
+
+            @Test
+            void shouldCreateDocumentInRootFolderIfParentFolderIdIsNull() {
+                when(folderService.getRootOrganizationFolder(testOrganization.getId())).thenReturn(rootOrganizationFolder);
+                when(entityManager.getReference(User.class, testUser.getId())).thenReturn(testUser);
+
+                File createdFile = Mockito.mock(File.class);
+                when(createdFile.getId()).thenReturn("new_file_id");
+
+                when(fileRepository.save(any(File.class))).thenReturn(createdFile);
+                when(fileContentRelationRepository.save(any(FileContentRelation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+                File result = documentService.createOrganizationDocument(testUser.getId(), testOrganization.getId(), "New Document", null);
+
+                assertNotNull(result);
+                assertEquals("new_file_id", result.getId());
+                verify(folderService, times(1)).getRootOrganizationFolder(testOrganization.getId());
+                verify(fileRepository, times(1)).save(any(File.class));
+                verify(fileContentRelationRepository, times(1)).save(any(FileContentRelation.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Modified our existing document creation endpoints so that they now accept a `name` and `parent_id` for a folder.