### PR TITLE
Resolved UpdatedAt Timestamp Issue for File Content Updates

### DIFF
--- a/src/main/java/com/org/project/model/File.java
+++ b/src/main/java/com/org/project/model/File.java
@@ -86,5 +86,11 @@ public class File{
     public Date getUpdatedAt() {
         return updatedAt;
     }
+
+    // This method is used to manually update the updatedAt field since
+    // it won't be updated if the user_id is not changed when updating the document
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
 }
 

--- a/src/main/java/com/org/project/service/DocumentService.java
+++ b/src/main/java/com/org/project/service/DocumentService.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Date;
+
 @Service
 public class DocumentService {
 
@@ -160,6 +162,10 @@ public class DocumentService {
 
         fileRepository.findById(documentId).ifPresent(file -> {
             file.setUpdatedUser(entityManager.getReference(User.class, userId));
+            
+            // Manually set updated at date since user_id might be the same as the current value
+            // and the @UpdateTimestamp annotation won't update the field in that case
+            file.setUpdatedAt(new Date());
             fileRepository.save(file);
         });
 


### PR DESCRIPTION
When a user would update a document and they were the last one to update it, the `updated_at`  timestamp would not change since the file row in MySQL would not actually get updated since no change was required. This PR adds in a fix that manually updates the files timestamp.